### PR TITLE
Update Blurble runtime to 46

### DIFF
--- a/app.drey.Blurble.json
+++ b/app.drey.Blurble.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "app.drey.Blurble",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "44",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "command" : "blurble",
     "finish-args" : [

--- a/app.drey.Blurble.json
+++ b/app.drey.Blurble.json
@@ -48,6 +48,10 @@
                     "url" : "https://gitlab.gnome.org/World/Blurble.git",
                     "tag" : "v0.4.0",
                     "commit" : "237668582004fa2eb82e9e2d5ec61e5a6b47e415"
+                },
+                {
+                    "type" : "patch",
+                    "path" : "fix_appdata.patch"
                 }
             ]
         }

--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,44 @@
+From e711375a94fe893a25aec465485c6c2650fbd0c0 Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Fri, 7 Jun 2024 20:57:38 +0300
+Subject: [PATCH] appdata: Update appdata
+
+- Fix appdata papercuts
+---
+ data/blurble.appdata.xml.in.in | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/data/blurble.appdata.xml.in.in b/data/blurble.appdata.xml.in.in
+index 72e8eea..373d34f 100644
+--- a/data/blurble.appdata.xml.in.in
++++ b/data/blurble.appdata.xml.in.in
+@@ -16,9 +16,15 @@
+     <screenshots>
+         <screenshot type="default">
+             <image>https://gitlab.gnome.org/World/Blurble/-/raw/v0.4.0/data/screenshots/screenshot-1.png</image>
++        </screenshot>
++        <screenshot>
+             <image>https://gitlab.gnome.org/World/Blurble/-/raw/v0.4.0/data/screenshots/screenshot-2.png</image>
+-            <image>https://gitlab.gnome.org/World/Blurble/-/raw/v0.4.0/data/screenshots/screenshot-3.png</image>
+-            <image>https://gitlab.gnome.org/World/Blurble/-/raw/v0.4.0/data/screenshots/screenshot-4.png</image>
++        </screenshot>
++        <screenshot>
++                <image>https://gitlab.gnome.org/World/Blurble/-/raw/v0.4.0/data/screenshots/screenshot-3.png</image>
++        </screenshot>
++        <screenshot>
++                <image>https://gitlab.gnome.org/World/Blurble/-/raw/v0.4.0/data/screenshots/screenshot-4.png</image>
+         </screenshot>
+     </screenshots>
+ 
+@@ -68,8 +74,6 @@
+     <url type="bugtracker">https://gitlab.gnome.org/World/Blurble/-/issues</url>
+     <url type="translate">https://l10n.gnome.org/module/Blurble</url>
+     <url type="donation">https://liberapay.com/pervoj</url>
+-    <url type="donation">https://ko-fi.com/pervoj</url>
+-    <url type="donation">https://paypal.me/pervoj</url>
+ 
+     <launchable type="desktop-id">@APP_ID@.desktop</launchable>
+     <translation type="gettext">@GETTEXT_PACKAGE@</translation>
+--
+libgit2 1.7.2
+


### PR DESCRIPTION
### Update Blurble runtime to 46

- Update Blurble runtime to 46 since runtime version 44 has reached end-of-life.

### appdata: Update appdata

- Fix appdata papercuts