### PR TITLE
Update GNOME runtime to 49 and Blueprint

### DIFF
--- a/app.drey.Blurble.json
+++ b/app.drey.Blurble.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "app.drey.Blurble",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "48",
+    "runtime-version" : "49",
     "sdk" : "org.gnome.Sdk",
     "command" : "blurble",
     "finish-args" : [
@@ -23,20 +23,6 @@
         "*.a"
     ],
     "modules" : [
-        {
-            "name" : "blueprint",
-            "buildsystem" : "meson",
-            "cleanup": [
-                "*"
-            ],
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://gitlab.gnome.org/GNOME/blueprint-compiler.git",
-                    "tag" : "v0.18.0"
-                }
-            ]
-        },
         {
             "name" : "blurble",
             "builddir" : true,

--- a/app.drey.Blurble.json
+++ b/app.drey.Blurble.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "app.drey.Blurble",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "46",
+    "runtime-version" : "48",
     "sdk" : "org.gnome.Sdk",
     "command" : "blurble",
     "finish-args" : [
@@ -32,8 +32,8 @@
             "sources" : [
                 {
                     "type" : "git",
-                    "url" : "https://gitlab.gnome.org/jwestman/blueprint-compiler.git",
-                    "tag" : "v0.4.0"
+                    "url" : "https://gitlab.gnome.org/GNOME/blueprint-compiler.git",
+                    "tag" : "v0.18.0"
                 }
             ]
         },


### PR DESCRIPTION
This PR updates GNOME runtime to version `49` and removes redundant `blueprint-compiler` module, as it is now a part of GNOME runtime. I've verified on my machine that the app works correctly with those changes applied.