### PR TITLE
Update the runtime version from 49 to 50, and more

### DIFF
--- a/app.drey.Blurble.json
+++ b/app.drey.Blurble.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "app.drey.Blurble",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "49",
+    "runtime-version" : "50",
     "sdk" : "org.gnome.Sdk",
     "command" : "blurble",
     "finish-args" : [
@@ -9,18 +9,6 @@
         "--socket=fallback-x11",
         "--device=dri",
         "--socket=wayland"
-    ],
-    "cleanup" : [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "/share/vala",
-        "*.la",
-        "*.a"
     ],
     "modules" : [
         {


### PR DESCRIPTION
- Update the runtime version to 50
- Drop ineffective cleanup commands